### PR TITLE
Fix interaction contexts and update Discord deps

### DIFF
--- a/commands/games/rio.js
+++ b/commands/games/rio.js
@@ -58,9 +58,11 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('rio')
     .setDescription('🗡️ Get World of Warcraft character and guild information from Raider.IO')
-    .setContexts(
-      InteractionContextType.Guild | InteractionContextType.DM | InteractionContextType.BotDM
-    )
+    .setContexts([
+      InteractionContextType.Guild,
+      InteractionContextType.PrivateChannel,
+      InteractionContextType.BotDM,
+    ])
     .addSubcommand((subcommand) =>
       subcommand
         .setName('character')

--- a/commands/games/roll.js
+++ b/commands/games/roll.js
@@ -43,7 +43,7 @@ module.exports = {
     .setDescription('🎲 Roll dice of various types')
     .setContexts([
       InteractionContextType.Guild,
-      InteractionContextType.DM,
+      InteractionContextType.PrivateChannel,
       InteractionContextType.BotDM,
     ])
     .addStringOption((option) =>

--- a/commands/games/wow.js
+++ b/commands/games/wow.js
@@ -121,7 +121,7 @@ module.exports = {
     .setDescription('🗡️ World of Warcraft information and utilities')
     .setContexts([
       InteractionContextType.Guild,
-      InteractionContextType.DM,
+      InteractionContextType.PrivateChannel,
       InteractionContextType.BotDM,
     ])
     .addSubcommand((subcommand) =>

--- a/commands/hardware/3d-print-status.js
+++ b/commands/hardware/3d-print-status.js
@@ -12,9 +12,11 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('3d-print-status')
     .setDescription('Replies with 3D Print Status!')
-    .setContexts(
-      InteractionContextType.Guild | InteractionContextType.DM | InteractionContextType.BotDM
-    ),
+    .setContexts([
+      InteractionContextType.Guild,
+      InteractionContextType.PrivateChannel,
+      InteractionContextType.BotDM,
+    ]),
   async execute(interaction) {
     // Check if the user is authorized
     if (interaction.user.id !== ownerId) {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ for (const file of eventFiles) {
 
 logger.info(`Loaded ${eventFiles.length} events.`)
 
-client.once('clientReady', async () => {
+client.once('ready', async () => {
   const { user, guilds, ws } = client
 
   logger.info(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@tcgdex/sdk": "^2.7.1",
-        "discord.js": "^14.24.2",
+        "discord.js": "^14.25.0",
         "dotenv": "^17.2.3",
-        "mongoose": "^8.19.3",
+        "mongoose": "^8.20.0",
         "pino": "^10.1.0"
       },
       "devDependencies": {
@@ -69,10 +69,12 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.6.1",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "discord-api-types": "^0.38.1"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -113,8 +115,13 @@
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.1.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -602,24 +609,28 @@
       "license": "MIT"
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.32",
+      "version": "0.38.34",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.34.tgz",
+      "integrity": "sha512-muq7xKGznj5MSFCzuIm/2TO7DpttuomUTemVM82fRqgnMl70YRzEyY24jlbiV6R9tzOTq6A6UnZ0bsfZeKD38Q==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.24.2",
+      "version": "14.25.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.0.tgz",
+      "integrity": "sha512-9rnJWTAkfauKTieYJ3oI4oncrSzpbJPWN1/XU+2H6wsHQPtqbOrXvgM0nFhSVnIbTo7nfUF7fzcYRevvRGjpzA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.13.0",
         "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/formatters": "^0.6.2",
         "@discordjs/rest": "^2.6.0",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.31",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.10.0",
@@ -1126,7 +1137,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.19.3",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.20.0.tgz",
+      "integrity": "sha512-SxqNb8yx+VOjIOx2l7HqkGvYuLC/T85d+jPvqGDdUbKJFz/5PVSsVxQzypQsX7chenYvq5bd8jIr4LtunedE7g==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.4",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "homepage": "https://github.com/destroyerdust/DestroyerBot#readme",
   "dependencies": {
     "@tcgdex/sdk": "^2.7.1",
-    "discord.js": "^14.24.2",
+    "discord.js": "^14.25.0",
     "dotenv": "^17.2.3",
-    "mongoose": "^8.19.3",
+    "mongoose": "^8.20.0",
     "pino": "^10.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
replace invalid DM context flag with PrivateChannel and use array syntax in rio, roll, wow, and 3d-print-status commands to satisfy builders validation listen for the correct ready client event
bump discord.js to 14.25.0 and mongoose to 8.20.0 (lockfile updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended game and hardware commands to function in private channels alongside existing contexts

* **Refactor**
  * Updated client initialization event handling

* **Chores**
  * Updated discord.js and mongoose dependencies to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->